### PR TITLE
Fix equation for Weierstrass form

### DIFF
--- a/src/main/java/edu/stanford/cs/crypto/efficientct/algebra/Secp256k1.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/algebra/Secp256k1.java
@@ -22,7 +22,7 @@ public class Secp256k1 extends BouncyCastleCurve {
         do {
             ECFieldElement x = new SecP256K1FieldElement(seed.mod(groupOrder()));
 
-            ECFieldElement rhs = x.square().multiply(x.add(curve.getA())).add(curve.getB());
+            ECFieldElement rhs = x.multiply(x.square().add(curve.getA())).add(curve.getB());
 
             ECFieldElement y = rhs.sqrt();
             if (y != null) {


### PR DESCRIPTION
This fixes the calculation for the Weierstrass form from `x^3 + ax^2 + b` to the correct form `x^3 + ax + b`. The issue does not appear for secp256k1 since there `a = 0`. However it appears when trying to use
this code for other curves.