### PR TITLE
zero knowledge vuln fix

### DIFF
--- a/src/main/java/edu/stanford/cs/crypto/efficientct/innerproduct/EfficientInnerProductVerifier.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/innerproduct/EfficientInnerProductVerifier.java
@@ -80,12 +80,6 @@ public class EfficientInnerProductVerifier<T extends GroupElement<T>> implements
         System.out.println(challengeVector2);
         ListX<BigInteger> sleft = challengeVector.map(proof.getA()::multiply);
         ListX<BigInteger> sright = challengeVector.reverse().map(proof.getB()::multiply);
-        System.out.printf("s[0]=%s\n", challengeVector.get(0));
-        System.out.printf("s[13]=%s\n", challengeVector.get(13));
-
-        System.out.printf("sl[10]=%s\n", sleft.get(10));
-        System.out.printf("sr[77]=%s\n", sright.get(77));
-
         BigInteger prod = proof.getA().multiply(proof.getB()).mod(q);
         T g = params.getGs().commit(sleft);
 

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/EfficientRangeProofVerifier.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/EfficientRangeProofVerifier.java
@@ -51,8 +51,8 @@ public class EfficientRangeProofVerifier<T extends GroupElement<T>> implements V
         BigInteger tauX = proof.getTauX();
         BigInteger mu = proof.getMu();
         BigInteger t = proof.getT();
-        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed));
-        T lhs = base.commit(t.subtract(k), tauX);
+        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed)).mod(q);
+        T lhs = base.commit(t.subtract(k).mod(q), tauX);
 
         T rhs = tCommits.commit(Arrays.asList(x, x.pow(2))).add(input.multiply(zSquared));
         equal(lhs, rhs, "Polynomial identity check failed, LHS: %s, RHS %s");

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofProver.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofProver.java
@@ -90,15 +90,6 @@ public class RangeProofProver<T extends GroupElement<T>> implements Prover<Gener
         InnerProductProver<T> prover = new InnerProductProver<>();
         InnerProductWitness innerProductWitness = new InnerProductWitness(l, r);
         InnerProductProof<T> proof = prover.generateProof(primeBase, P, innerProductWitness,uChallenge);
-        System.out.println("y " +y);
-        System.out.println("z " +z);
-
-        System.out.println("x " +x);
-        System.out.println("u " +uChallenge);
-        T lhs = base.commit(t.subtract(k), tauX);
-        System.out.println(lhs);
-        T rhs = new GeneratorVector<>(polyCommitment.getCommitments(),parameter.getGroup()).commit(Arrays.asList(x, x.pow(2))).add(commitment.multiply(zSquared));
-        System.out.println(rhs);
         return new RangeProof<>(a, s, new GeneratorVector<T>(polyCommitment.getCommitments(), parameter.getGroup()), tauX, mu, t, proof);
     }
 }

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofProver.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofProver.java
@@ -64,7 +64,7 @@ public class RangeProofProver<T extends GroupElement<T>> implements Prover<Gener
         FieldVector twoTimesZSquared = twos.times(zSquared);
         FieldVector r0 = ys.hadamard(aR.add(z)).add(twoTimesZSquared);
         FieldVector r1 = sR.hadamard(ys);
-        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed));
+        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed)).mod(q);
         BigInteger t0 = k.add(zSquared.multiply(number)).mod(q);
         BigInteger t1 = l1.innerPoduct(r0).add(l0.innerPoduct(r1));
         BigInteger t2 = l1.innerPoduct(r1);

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofVerifier.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/rangeproof/RangeProofVerifier.java
@@ -55,8 +55,8 @@ public class RangeProofVerifier<T extends GroupElement<T>> implements Verifier<G
         BigInteger tauX = proof.getTauX();
         BigInteger mu = proof.getMu();
         BigInteger t = proof.getT();
-        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed));
-        T lhs = base.commit(t.subtract(k), tauX);
+        BigInteger k = ys.sum().multiply(z.subtract(zSquared)).subtract(zCubed.shiftLeft(n).subtract(zCubed)).mod(q);
+        T lhs = base.commit(t.subtract(k).mod(q), tauX);
         T rhs = tCommits.commit(Arrays.asList(x, x.pow(2))).add(input.multiply(zSquared));
         System.out.println("y " + y);
         System.out.println("z " + z);

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolProver.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolProver.java
@@ -22,16 +22,19 @@ public class SigmaProtocolProver<T extends GroupElement<T>> implements Prover<Pe
         T yBar = input.getStatement().getyBar();
         T CRNew = input.getStatement().getBalanceCommitNewR();
         T D = input.getStatement().getInOutR();
+        T HR = input.getHR();
+
         BigInteger z = input.getZ();
         BigInteger zSquared = z.pow(2).mod(q);
         BigInteger zCubed = zSquared.multiply(z).mod(q);
+        BigInteger zFourth = zCubed.multiply(z).mod(q);
 
         BigInteger kR = ProofUtils.randomNumber();
         BigInteger kX = ProofUtils.randomNumber();
         T Ay = g.multiply(kX);
         T AD = g.multiply(kR);
         T ADiff = y.subtract(yBar).multiply(kR);
-        T At = D.multiply(zSquared).add(CRNew.multiply(zCubed)).multiply(kX);
+        T At = D.multiply(zSquared).add(CRNew.multiply(zCubed)).add(HR.multiply(zFourth)).multiply(kX);
 
         BigInteger challenge;
         if (salt.isPresent()) {

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolStatement.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolStatement.java
@@ -7,13 +7,17 @@ import java.math.BigInteger;
 public class SigmaProtocolStatement<T extends GroupElement<T>> {
     private final ZetherStatement<T> statement;
     private final T tCommits;
+    private final T HL;
+    private final T HR;
     private final BigInteger t;
     private final BigInteger z;
     private final BigInteger tauX;
 
-    public SigmaProtocolStatement(ZetherStatement<T> statement, T tCommits, BigInteger t, BigInteger tauX, BigInteger z) {
+    public SigmaProtocolStatement(ZetherStatement<T> statement, T tCommits, T HL, T HR, BigInteger t, BigInteger tauX, BigInteger z) {
         this.statement = statement;
         this.tCommits = tCommits;
+        this.HL = HL;
+        this.HR = HR;
         this.t = t;
         this.tauX = tauX;
         this.z = z;
@@ -27,9 +31,11 @@ public class SigmaProtocolStatement<T extends GroupElement<T>> {
         return z;
     }
 
-    public ZetherStatement<T> getStatement() {
-        return statement;
-    }
+    public ZetherStatement<T> getStatement() { return statement; }
+
+    public T getHL() { return HL; }
+
+    public T getHR() { return HR; }
 
     public T gettCommits() {
         return tCommits;

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolVerifier.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/SigmaProtocolVerifier.java
@@ -22,10 +22,12 @@ public class SigmaProtocolVerifier<T extends GroupElement<T>> implements Verifie
         T C = input.getStatement().getOutL();
         T CBar = input.getStatement().getInL();
         T D = input.getStatement().getInOutR();
+        T HL = input.getHL();
+        T HR = input.getHR();
         BigInteger z = input.getZ();
         BigInteger zSquared = z.pow(2).mod(q);
         BigInteger zCubed = zSquared.multiply(z).mod(q);
-
+        BigInteger zFourth = zCubed.multiply(z).mod(q);
 
         BigInteger c = proof.getC();
         BigInteger minusC = c.negate().mod(q);
@@ -38,6 +40,7 @@ public class SigmaProtocolVerifier<T extends GroupElement<T>> implements Verifie
         T ADiff = y.subtract(yBar).multiply(sR).add(C.subtract(CBar).multiply(minusC));
         //T CCommit=CL.add(C.multiply(zMin1)).multiply(proof.getC()).add(D.multiply(zMin1.negate()).subtract(CR).multiply(sX)).multiply(zSquared);
         T cCommit = C.multiply(c.multiply(zSquared)).subtract(CRNew.multiply(sX.multiply(zCubed))).add(CLNew.multiply(c.multiply(zCubed))).subtract(D.multiply(sX.multiply(zSquared)));
+        cCommit = cCommit.add(HL.multiply(c.multiply(zFourth))).subtract(HR.multiply(sX.multiply(zFourth)));
         T At = g.multiply(input.getT().multiply(c)).add(params.h.multiply(input.getTauX().multiply(c))).subtract(cCommit).subtract(input.gettCommits().multiply(c));
         System.out.printf("Assert.equal(0x%s,As[0].X,\"As[0]\");\n",((BN128Point)Ay).getPoint().normalize().getXCoord());
         System.out.printf("Assert.equal(0x%s,As[1].X,\"As[1]\");\n",((BN128Point)AD).getPoint().normalize().getXCoord());

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/ZetherProof.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/ZetherProof.java
@@ -5,6 +5,7 @@ import edu.stanford.cs.crypto.efficientct.algebra.GroupElement;
 import edu.stanford.cs.crypto.efficientct.innerproduct.ExtendedInnerProductProof;
 import edu.stanford.cs.crypto.efficientct.innerproduct.InnerProductProof;
 import edu.stanford.cs.crypto.efficientct.linearalgebra.GeneratorVector;
+import edu.stanford.cs.crypto.efficientct.util.ProofUtils;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -13,6 +14,8 @@ import java.util.List;
 public class ZetherProof<T extends GroupElement<T>> implements Proof {
     private final T aI;
     private final T s;
+    private final T HL;
+    private final T HR;
     private final GeneratorVector<T> tCommits;
     private final BigInteger t;
     private final BigInteger tauX;
@@ -22,9 +25,11 @@ public class ZetherProof<T extends GroupElement<T>> implements Proof {
     private final ExtendedInnerProductProof<T> productProof;
 
 
-    public ZetherProof(T aI, T s, GeneratorVector<T> tCommits, BigInteger t, BigInteger tauX, BigInteger mu, SigmaProof sigmaProof, ExtendedInnerProductProof<T> productProof) {
+    public ZetherProof(T aI, T s, T HL, T HR, GeneratorVector<T> tCommits, BigInteger t, BigInteger tauX, BigInteger mu, SigmaProof sigmaProof, ExtendedInnerProductProof<T> productProof) {
         this.aI = aI;
         this.s = s;
+        this.HL = HL;
+        this.HR = HR;
         this.tCommits = tCommits;
         this.t = t;
         this.tauX = tauX;
@@ -41,6 +46,9 @@ public class ZetherProof<T extends GroupElement<T>> implements Proof {
         return s;
     }
 
+    public T getHL() { return HL; }
+
+    public T getHR() { return HR; }
 
     public BigInteger getT() {
         return t;
@@ -75,9 +83,13 @@ public class ZetherProof<T extends GroupElement<T>> implements Proof {
         byteArrs.add(productProof.serialize());
         byteArrs.add(aI.canonicalRepresentation());
         byteArrs.add(s.canonicalRepresentation());
+        byteArrs.add(HL.canonicalRepresentation());
+        byteArrs.add(HR.canonicalRepresentation());
         tCommits.stream().map(GroupElement::canonicalRepresentation).forEach(byteArrs::add);
         BigInteger q = tCommits.getGroup().groupOrder();
-        byteArrs.add(t.mod(q).toByteArray());
+        byteArrs.add(t.mod(q).toByteArray()); // warning: this and the below might wind up shorter than you expect
+        byteArrs.add(tauX.mod(q).toByteArray());
+        byteArrs.add(mu.mod(q).toByteArray());
         int totalBytes = byteArrs.stream().mapToInt(arr -> arr.length).sum();
         byte[] fullArray = new byte[totalBytes];
         int currIndex = 0;

--- a/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/ZetherVerifier.java
+++ b/src/main/java/edu/stanford/cs/crypto/efficientct/zetherprover/ZetherVerifier.java
@@ -34,15 +34,17 @@ public class ZetherVerifier<T extends GroupElement<T>> implements Verifier<Gener
         int n = vectorBase.getGs().size();
         T a = proof.getaI();
         T s = proof.getS();
+        T HL = proof.getHL();
+        T HR = proof.getHR();
 
         BigInteger q = params.getGroup().groupOrder();
         BigInteger y;
         BigInteger statementHash=ProofUtils.computeChallenge(q, zetherStatement.getY(), zetherStatement.getyBar(), zetherStatement.getBalanceCommitNewL(), zetherStatement.getBalanceCommitNewR(), zetherStatement.getInL(), zetherStatement.getOutL(), zetherStatement.getInOutR());
         if (salt.isPresent()) {
 
-            y = ProofUtils.computeChallenge(q,new BigInteger[]{ salt.get(),statementHash} , a, s);
+            y = ProofUtils.computeChallenge(q,new BigInteger[]{ salt.get(),statementHash} , a, s, HL, HR);
         } else {
-            y = ProofUtils.computeChallenge(q,statementHash, a, s);
+            y = ProofUtils.computeChallenge(q,statementHash, a, s, HL, HR);
 
         }
         FieldVector ys = FieldVector.from(VectorX.iterate(n, BigInteger.ONE, y::multiply), q);
@@ -68,7 +70,7 @@ public class ZetherVerifier<T extends GroupElement<T>> implements Verifier<Gener
         BigInteger t = proof.getT();
         BigInteger mu = proof.getMu();
         BigInteger tauX = proof.getTauX();
-        SigmaProtocolStatement<T> sigmaStatement = new SigmaProtocolStatement<>(zetherStatement, tEval, t.subtract(k), tauX, z);
+        SigmaProtocolStatement<T> sigmaStatement = new SigmaProtocolStatement<>(zetherStatement, tEval, proof.getHL(), proof.getHR(), t.subtract(k), tauX, z);
         SigmaProof sigmaProof = proof.getSigmaProof();
         sigmaVerifier.verify(base, sigmaStatement, sigmaProof, x);
         BigInteger uChallenge = ProofUtils.challengeFromints(q, sigmaProof.getC(), t, tauX, mu);


### PR DESCRIPTION
fixes a vuln in Zether which could have allowed the verifier (or an onlooker) to determine b* and b' using only 2^64 work (or less if she can "guess" these values). essentially, no 0th-order randomness was included in \tau_X; this caused A_t * C_commit (easily computable by the verifier) to equal the quantity g^{-c * (b*z^2 + b'*z^3) }, which can be brute-forced.

this PR adds 0th-order randomness \gamma to \tau_X. the Pedersen randomness h^\gamma is—just like the messages g^b* and g^b'—ElGamal encrypted under the sender's public key; it can only be decrypted in conjunction with the other two, giving the verifier only the proper Pedersen commitment (g^{b\*z^2 + b'\*z^3} h^{\gamma\*z^4})^c, which hides b* and b'.

also fixes a few small other things.